### PR TITLE
setup.py: require execnet

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     zip_safe = False,
 
     install_requires=[
+        'execnet',
         'setuptools',
         'tambo',
         'remoto',


### PR DESCRIPTION
We import from execnet, so let's be explicit about requiring it