### PR TITLE
setup.py: do not require setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
 
     install_requires=[
         'execnet',
-        'setuptools',
         'tambo',
         'remoto',
     ] + install_requires,


### PR DESCRIPTION
We use setuptools to package ceph-medic, but we don't import from setuptools specifically within ceph-medic itself.