### PR TITLE
MANIFEST.in: delete unused file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
 include *.rst
 include LICENSE
-include scripts/ceph-medic
 include tox.ini


### PR DESCRIPTION
It's `bin/ceph-medic`, not `scripts/ceph-medic`, and setuptools already includes the `bin/` version because we pass it into `setup()` in `setup.py`.