### PR TITLE
ignore host groups that do not exist in ceph_medic.metadata

### DIFF
--- a/ceph_medic/tests/util/test_configuration.py
+++ b/ceph_medic/tests/util/test_configuration.py
@@ -30,6 +30,19 @@ class TestFlatInventory(object):
         assert len(result['mons']) == 1
         assert len(result['osds']) == 1
 
+    def test_ignores_unknown_groups(self, tmpdir):
+        filename = os.path.join(str(tmpdir), 'hosts')
+        contents = """
+        [mons]
+        mon0
+
+        [test]
+        node1
+        """
+        make_hosts_file(filename, contents)
+        result = configuration.AnsibleInventoryParser(filename).nodes
+        assert 'test' not in result
+
 
 class TestNestedInventory(object):
 
@@ -57,7 +70,7 @@ class TestNestedInventory(object):
         """
         make_hosts_file(filename, contents)
         result = configuration.AnsibleInventoryParser(filename).nodes
-        assert result['atlanta'][0]['host'] == 'mon0'
+        assert result['mons'][0]['host'] == 'mon0'
 
     def test_nested_levels_populates(self, tmpdir):
         filename = os.path.join(str(tmpdir), 'hosts')

--- a/ceph_medic/util/configuration.py
+++ b/ceph_medic/util/configuration.py
@@ -10,7 +10,7 @@ import logging
 import os
 from os import path
 import re
-from ceph_medic import terminal
+from ceph_medic import terminal, metadata
 
 logger = logging.getLogger(__name__)
 
@@ -335,6 +335,19 @@ class AnsibleInventoryParser(object):
                 else:
                     self.hosts[host_group].append(host_item)
         self.expand_nodes()
+        self.filter_groups()
+
+    def filter_groups(self):
+        """
+        Removes any groups from self.nodes that do not exist in
+        ceph_medic.metadata. We want to do this because we don't care
+        about nodes or groups in an inventory that are not part of
+        the ceph cluster.
+        """
+        groups = [key for key in self.nodes.keys()]
+        for group in groups:
+            if group not in metadata:
+                del self.nodes[group]
 
     def expand_nested_group(self, parent_group, group):
         """


### PR DESCRIPTION
We shouldn't store nodes in metadata['nodes'] that are not a part
of the ceph cluster, meaning they do not belong in a group that
ceph-medic knows as a ceph daemon type.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>