### PR TITLE
checks: adds osds.check_osd_ceph_fsid

### DIFF
--- a/ceph_medic/checks/osds.py
+++ b/ceph_medic/checks/osds.py
@@ -1,0 +1,22 @@
+
+
+#
+# Utilities
+#
+
+def get_osd_ceph_fsids(data):
+    fsids = []
+    for file_path in data['paths']['/var/lib/ceph']['files'].keys():
+        if "ceph_fsid" in file_path:
+            fsids.append(data['paths']['/var/lib/ceph']['files'][file_path]['contents'].strip())
+    return set(fsids)
+
+
+def check_osd_ceph_fsid(host, data):
+    code = 'WOSD1'
+    msg = "Multiple ceph_fsid values found: %s"
+
+    current_fsids = get_osd_ceph_fsids(data)
+
+    if len(current_fsids) > 1:
+        return code, msg % ", ".join(current_fsids)

--- a/ceph_medic/tests/checks/test_osds.py
+++ b/ceph_medic/tests/checks/test_osds.py
@@ -1,0 +1,12 @@
+from ceph_medic.checks import osds
+
+
+class TestOSDS(object):
+
+    def test_fails_check_ceph_fsid(self):
+        data = {'paths': {'/var/lib/ceph': {'files': {
+            '/var/lib/ceph/osd/ceph-0/ceph_fsid': {'contents': "fsid1"},
+            '/var/lib/ceph/osd/ceph-1/ceph_fsid': {'contents': "fsid2"},
+        }}}}
+        result = osds.check_osd_ceph_fsid(None, data)
+        assert "WOSD1" in result

--- a/docs/source/codes.rst
+++ b/docs/source/codes.rst
@@ -14,3 +14,4 @@ Below you'll find a list of checks that are performed with the ``check`` subcomm
 
    codes/common.rst
    codes/mons.rst
+   codes/osds.rst

--- a/docs/source/codes/osds.rst
+++ b/docs/source/codes/osds.rst
@@ -1,0 +1,18 @@
+OSDs
+====
+
+The following checks indicate issue with OSD nodes.
+
+Warnings
+--------
+
+
+.. _WOSD1:
+
+WOSD1
+_____
+Multiple ceph_fsid values found in /var/lib/ceph/osd.
+
+This might mean you are hosting OSDs for many clusters on
+this node or that some OSDs are misconfigured to join the
+clusters you expect.


### PR DESCRIPTION
This will issue the warning code WOSD1 if multiple
values are found in ceph_fsid files that are located
in the osd directories at /var/lib/ceph/osd

This is only a warning because you could want to host
OSDs on a single node for multiple ceph clusters.

Fixes: https://github.com/ceph/ceph-medic/issues/2

Signed-off-by: Andrew Schoen <aschoen@redhat.com>