### PR TITLE
colocated osds is a warning

### DIFF
--- a/ceph_medic/runner.py
+++ b/ceph_medic/runner.py
@@ -68,13 +68,16 @@ class Runner(object):
                     self.failed += 1
                     if not has_error:
                         terminal.loader.write(' %s' % terminal.red(host))
-                    terminal.write.write('\n')
+                        terminal.write.write('\n')
 
                     if code.startswith('E'):
                         code = terminal.red(code)
                     elif code.startswith('W'):
                         code = terminal.yellow(code)
-                    terminal.write.write("   %s: %s" % (code, message))
+                    if not has_error:
+                        terminal.write.write("   %s: %s\n" % (code, message))
+                    else:
+                        terminal.write.write("   %s: %s" % (code, message))
                     has_error = True
                 else:
                     self.passed += 1

--- a/ceph_medic/tests/checks/test_mons.py
+++ b/ceph_medic/tests/checks/test_mons.py
@@ -77,3 +77,16 @@ class TestGetMonitorDirs(object):
             '/var/lib/ceph/something'])
 
         assert result == set(['ceph-mon-1', 'ceph-mon-2'])
+
+
+class TestOsdDirs(object):
+
+    def test_get_osd_dirs_nested_multiple(self):
+        result = mons.get_osd_dirs([
+            '/var/lib/ceph/osd/ceph-1',
+            '/var/lib/ceph/osd/ceph-1/nested/dir/',
+            '/var/lib/ceph/osd/ceph-1/other/nested',
+            '/var/lib/ceph/osd/ceph-2',
+            '/var/lib/ceph/something'])
+
+        assert result == set(['ceph-1', 'ceph-2'])

--- a/docs/source/codes/mons.rst
+++ b/docs/source/codes/mons.rst
@@ -21,3 +21,10 @@ Warnings
 WMON1
 _____
 Multiple monitor directories are found on the same host.
+
+.. _WMON2:
+
+WMON2
+_____
+Collocated OSDs in monitors nodes where found on the same host.
+


### PR DESCRIPTION
Fixes issue #30 

And fixes another issue with the runner where multi-errors where messed up:

    ------------ mons ------------
     mira049
     mira060                                                               eph-12,ceph-18
     mira021                                                               ceph-22,ceph-23,ceph-10,ceph-66,ceph-74
       EMON2: colocated OSDs found: ceph-5,ceph-6,ceph-11,ceph-15,ceph-17,ceph-19,ceph-20


To:

    ------------ mons ------------
     mira049
       EMON2: colocated OSDs found: ceph-7,ceph-46,ceph-40,ceph-49,ceph-8,ceph-12,ceph-18
     mira060
       EMON2: colocated OSDs found: ceph-1,ceph-69,ceph-25,ceph-26,ceph-27,ceph-22,ceph-23,ceph-10,ceph-66,ceph-74
     mira021
       EMON2: colocated OSDs found: ceph-5,ceph-6,ceph-11,ceph-15,ceph-17,ceph-19,ceph-20
