### PR TITLE
debian: point pybuild at pytest directory

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -5,5 +5,7 @@ export DH_VERBOSE=1
 
 export PYBUILD_NAME=ceph-medic
 
+export PYBUILD_TEST_ARGS=ceph_medic/tests
+
 %:
 	dh $@ --buildsystem pybuild --with python2


### PR DESCRIPTION
Prior to this change, we were running pytest on the root-level "tests" directory, which was failing because it does not contain the unit tests.