### PR TITLE
debian: delete old ceph-doctor file

### DIFF
--- a/debian/ceph-doctor.install
+++ b/debian/ceph-doctor.install
@@ -1,1 +1,0 @@
-./scripts/ceph-medic  /usr/bin


### PR DESCRIPTION
The pybuild helper installs `/usr/bin/ceph-doctor` without this, since it just invokes setuptools to do the install, and we've configured `scripts/ceph-medic` in `setup.py`.