### PR TITLE
tests: add basic main test

### DIFF
--- a/ceph-medic.spec.in
+++ b/ceph-medic.spec.in
@@ -16,6 +16,7 @@ BuildRequires:  python-setuptools
 BuildRequires:  pytest
 BuildRequires:  python-remoto
 BuildRequires:  python-mock
+BuildRequires:  python-tambo
 Requires:       python-remoto
 Requires:       python-tambo
 Requires:       python-execnet

--- a/ceph_medic/tests/test_main.py
+++ b/ceph_medic/tests/test_main.py
@@ -1,0 +1,6 @@
+import ceph_medic.main
+
+
+class TestMain(object):
+    def test_main(self):
+        assert ceph_medic.main

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,8 @@ Build-Depends:
  dh-python,
  python,
  python-pytest,
- python-setuptools
+ python-setuptools,
+ python-tambo
 X-Python-Version: >= 2.7
 Standards-Version: 3.9.7
 Homepage: http://ceph.com/


### PR DESCRIPTION
Test that we can simply import main.py.

This is really trivial, but at least we ensure that importing our dependencies (for example, tambo) works.