### PR TITLE
show a nice error message if --inventory path doesn't exist

### DIFF
--- a/ceph_medic/tests/util/test_configuration.py
+++ b/ceph_medic/tests/util/test_configuration.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 from ceph_medic.util import configuration
 
 
@@ -42,6 +43,10 @@ class TestFlatInventory(object):
         make_hosts_file(filename, contents)
         result = configuration.AnsibleInventoryParser(filename).nodes
         assert 'test' not in result
+
+    def test_hosts_file_does_not_exist(self):
+        with pytest.raises(SystemExit):
+            configuration.load_hosts(_path="/fake/path")
 
 
 class TestNestedInventory(object):

--- a/ceph_medic/util/configuration.py
+++ b/ceph_medic/util/configuration.py
@@ -8,6 +8,7 @@ except ImportError:
     from io import StringIO
 import logging
 import os
+import sys
 from os import path
 import re
 from ceph_medic import terminal, metadata
@@ -102,6 +103,9 @@ def load_hosts(_path=None):
     is not loaded. Try the hardest to load one, and return an empty dictionary
     if nothing is found.
     """
+    if _path and not os.path.exists(_path):
+        terminal.error("the given inventory path does not exist: %s" % _path)
+        sys.exit()
     _path = _path or get_host_file()
     return AnsibleInventoryParser(_path)
 


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1489444

Signed-off-by: Andrew Schoen <aschoen@redhat.com>