### PR TITLE
print friendly message with an invalid --ssh-config

### DIFF
--- a/ceph_medic/main.py
+++ b/ceph_medic/main.py
@@ -1,5 +1,6 @@
 from ceph_medic import check, log
 import sys
+import os
 from textwrap import dedent
 from tambo import Transport
 from execnet.gateway_bootstrap import HostNotFound
@@ -105,6 +106,11 @@ Global Options:
 
         # SSH config
         ceph_medic.config['ssh_config'] = parser.get('--ssh-config')
+        if ceph_medic.config['ssh_config']:
+            ssh_config_path = ceph_medic.config['ssh_config']
+            if not os.path.exists(ssh_config_path):
+                terminal.error("the given ssh config path does not exist: %s" % ssh_config_path)
+                sys.exit()
 
         ceph_medic.config['cluster_name'] = parser.get('--cluster')
         ceph_medic.metadata['cluster_name'] = 'ceph'

--- a/ceph_medic/tests/test_main.py
+++ b/ceph_medic/tests/test_main.py
@@ -1,6 +1,12 @@
+import pytest
 import ceph_medic.main
 
 
 class TestMain(object):
     def test_main(self):
         assert ceph_medic.main
+
+    def test_invalid_ssh_config(self):
+        argv = ["ceph-medic", "--ssh-config", "/does/not/exist"]
+        with pytest.raises(SystemExit):
+            ceph_medic.main.Medic(argv)


### PR DESCRIPTION
If the path given to --ssh-config does not exist then ceph-medic stops
before checks are started and prints a message.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>