### PR TITLE
Test report output, and ensure newlines are added

### DIFF
--- a/ceph_medic/runner.py
+++ b/ceph_medic/runner.py
@@ -54,6 +54,7 @@ class Runner(object):
                     # the code is ignored, maybe introspecting the function?
                     result = getattr(module, check)(host, data)
                 except Exception as error:
+                    result = None
                     logger.exception('check had an unhandled error: %s', check)
                     self.errors.append(error)
                 if result:
@@ -74,10 +75,7 @@ class Runner(object):
                         code = terminal.red(code)
                     elif code.startswith('W'):
                         code = terminal.yellow(code)
-                    if not has_error:
-                        terminal.write.write("   %s: %s\n" % (code, message))
-                    else:
-                        terminal.write.write("   %s: %s" % (code, message))
+                    terminal.write.write("   %s: %s\n" % (code, message))
                     has_error = True
                 else:
                     self.passed += 1

--- a/ceph_medic/tests/__init__.py
+++ b/ceph_medic/tests/__init__.py
@@ -1,4 +1,5 @@
 
 # helps reset altered metadata in tests
-base_metadata = {'rgws': {}, 'mgrs': {}, 'mdss':{}, 'clients': {}, 'osds':{}, 'mons':{}, 'nodes': {}}
+base_metadata = {'rgws': {}, 'mgrs': {}, 'mdss':{}, 'clients': {},
+        'osds':{}, 'mons':{}, 'nodes': {}, 'cluster_name': 'ceph'}
 

--- a/ceph_medic/tests/conftest.py
+++ b/ceph_medic/tests/conftest.py
@@ -1,0 +1,59 @@
+import pytest
+import random
+from ceph_medic import runner
+
+
+class FakeWriter(object):
+
+    def __init__(self):
+        self.calls = []
+        self.write = self.raw
+        self.loader = self
+
+    def raw(self, string):
+        self.calls.append(string)
+
+    def bold(self, string):
+        self.calls.append(string)
+
+    def get_output(self):
+        return '\n'.join(self.calls)
+
+
+@pytest.fixture
+def mon_keyring():
+    def make_keyring(default=False):
+        if default:
+            key = "AQBvaBFZAAAAABAA9VHgwCg3rWn8fMaX8KL01A=="
+        else:
+            key = "%032x==" % random.getrandbits(128)
+
+        return """
+    [mon.]
+        key = %s
+            caps mon = "allow *"
+        """ % key
+    return make_keyring
+
+
+@pytest.fixture
+def terminal(monkeypatch):
+    fake_writer = FakeWriter()
+    monkeypatch.setattr(runner.terminal, 'write', fake_writer)
+    return fake_writer
+
+@pytest.fixture
+def data():
+    """
+    Default data structure for remote nodes
+    """
+    def make_data():
+        return {
+            'ceph': {'installed': True},
+            'paths': {
+                '/etc/ceph': {'files': {}, 'dirs': {}},
+                '/var/lib/ceph': {'files': {}, 'dirs': {}},
+            }
+        }
+    return make_data
+

--- a/ceph_medic/tests/test_runner.py
+++ b/ceph_medic/tests/test_runner.py
@@ -1,4 +1,3 @@
-import pytest
 import ceph_medic
 from ceph_medic import runner
 from ceph_medic.tests import base_metadata
@@ -49,19 +48,14 @@ class TestReport(object):
         runner.metadata = base_metadata
         runner.metadata['nodes'] = {}
 
-    def test_reports_errors(self, monkeypatch):
-        fake_writer = FakeWriter()
-        monkeypatch.setattr(runner.terminal, 'write', fake_writer)
+    def test_reports_errors(self, terminal):
         self.results.errors = ['I am an error']
         runner.report(self.results)
-        assert 'While running checks, ceph-medic had unhandled errors' in fake_writer.calls[-1]
+        assert 'While running checks, ceph-medic had unhandled errors' in terminal.calls[-1]
 
-    def test_reports_no_errors(self, monkeypatch):
-        fake_writer = FakeWriter()
-        monkeypatch.setattr(runner.terminal, 'write', fake_writer)
+    def test_reports_no_errors(self, terminal):
         runner.report(self.results)
-        assert fake_writer.calls[0] == '\n0 passed, on 0 hosts'
-
+        assert terminal.calls[0] == '\n0 passed, on 0 hosts'
 
 
 class TestReportBasicOutput(object):

--- a/ceph_medic/tests/test_runner.py
+++ b/ceph_medic/tests/test_runner.py
@@ -1,3 +1,4 @@
+import pytest
 import ceph_medic
 from ceph_medic import runner
 from ceph_medic.tests import base_metadata
@@ -33,15 +34,6 @@ class TestRunner(object):
         assert run.total_hosts == 4
 
 
-class FakeWriter(object):
-
-    def __init__(self):
-        self.calls = []
-
-    def raw(self, string):
-        self.calls.append(string)
-
-
 class TestReport(object):
 
     def setup(self):
@@ -69,3 +61,94 @@ class TestReport(object):
         monkeypatch.setattr(runner.terminal, 'write', fake_writer)
         runner.report(self.results)
         assert fake_writer.calls[0] == '\n0 passed, on 0 hosts'
+
+
+
+class TestReportBasicOutput(object):
+
+    def setup(self):
+        # clear metadata
+        ceph_medic.metadata = base_metadata
+        runner.metadata = base_metadata
+        runner.metadata['nodes'] = {}
+        runner.Runner().run()
+
+    def test_has_version(self, terminal):
+        assert 'Version: ' in terminal.get_output()
+
+    def test_has_cluster_name(self, terminal):
+        assert 'Cluster Name: "ceph"' in terminal.get_output()
+
+    def test_has_no_hosts(self, terminal):
+        assert 'Total hosts: [0]' in terminal.get_output()
+
+    def test_has_a_header(self, terminal):
+        assert '==  Starting remote check session  ==' in terminal.get_output()
+
+    def test_has_no_OSDs(self, terminal):
+        assert 'OSDs:    0' in terminal.get_output()
+
+    def test_has_no_MONs(self, terminal):
+        assert 'MONs:    0' in terminal.get_output()
+
+    def test_has_no_Clients(self, terminal):
+        assert 'Clients:    0' in terminal.get_output()
+
+    def test_has_no_MDSs(self, terminal):
+        assert 'MDSs:    0' in terminal.get_output()
+
+    def test_has_no_MGRs(self, terminal):
+        assert 'MGRs:       0' in terminal.get_output()
+
+    def test_has_no_RGWs(self, terminal):
+        assert 'RGWs:    0' in terminal.get_output()
+
+
+class TestReportErrors(object):
+
+    def setup(self):
+        # clear metadata
+        ceph_medic.metadata = base_metadata
+        runner.metadata = base_metadata
+        runner.metadata['nodes'] = {}
+
+    def test_get_new_lines_in_errors(self, terminal, mon_keyring, data, monkeypatch):
+        data_node1 = data()
+        data_node2 = data()
+        data_node1['paths']['/var/lib/ceph']['files'] = {
+            '/var/lib/ceph/mon/ceph-0/keyring': {'contents': mon_keyring()}
+        }
+        data_node1['paths']['/var/lib/ceph']['dirs'] = {
+            '/var/lib/ceph/osd/ceph-10': {},
+            '/var/lib/ceph/osd/ceph-11': {},
+            '/var/lib/ceph/osd/ceph-12': {},
+            '/var/lib/ceph/osd/ceph-13': {},
+            '/var/lib/ceph/osd/ceph-0': {},
+            '/var/lib/ceph/osd/ceph-1': {},
+            '/var/lib/ceph/osd/ceph-2': {},
+            '/var/lib/ceph/osd/ceph-3': {},
+        }
+
+        data_node2['paths']['/var/lib/ceph']['files'] = {
+            '/var/lib/ceph/mon/ceph-1/keyring': {'contents': mon_keyring()},
+        }
+        data_node2['paths']['/var/lib/ceph']['dirs'] = {
+            '/var/lib/ceph/osd/ceph-10': {},
+            '/var/lib/ceph/osd/ceph-11': {},
+            '/var/lib/ceph/osd/ceph-12': {},
+            '/var/lib/ceph/osd/ceph-13': {},
+            '/var/lib/ceph/osd/ceph-0': {},
+            '/var/lib/ceph/osd/ceph-1': {},
+            '/var/lib/ceph/osd/ceph-2': {},
+            '/var/lib/ceph/osd/ceph-3': {},
+        }
+
+        # set the data everywhere we need it
+        ceph_medic.metadata['mons'] = {'node1': data_node1, 'node2': data_node2}
+        monkeypatch.setattr(ceph_medic.checks.mons, 'metadata', ceph_medic.metadata)
+
+        runner.Runner().run()
+        # Any line that is an error or a warning *must* end with a newline
+        for line in terminal.calls:
+            if line.lstrip().startswith(('E', 'W')):
+                assert line.endswith('\n')


### PR DESCRIPTION
This is the second try to fix this problem:

     node9
       ECOM1: /etc/ceph/ceph.conf does not exist
       ECOM2: ceph executable was not found in common paths when running `which`   ECOM2: ceph executable was not found in common paths when running `which`   ECOM3: /var/lib/ceph could not be parsed: [Errno 2] No such file or directory: '/va mira049                                                               ch file or directory: '/var/lib/ceph'   EMON1: secret key "None" is different than host(s): mira049,mira060,mira021
       WMON2: collocated OSDs found: ceph-40,ceph-46,ceph-49,ceph-7,ceph-8,ceph-12,ceph-18
     mira060                                                               erent than host(s): node9,node3
       WMON2: collocated OSDs found: ceph-1,ceph-69,ceph-25,ceph-26,ceph-27,ceph-22,ceph-23,ceph-10,ceph-66,ceph-74
     node3                                                                 erent than host(s): node9,node3
       WMON2: collocated OSDs found: ceph-5
     mira021                                                               mira021
       WMON2: collocated OSDs found: ceph-5,ceph-6,ceph-11,ceph-15,ceph-17,ceph-19,ceph-20
       EMON1: secret key "AQCRWAtSAAAAABAAtLVEZ9qH0MLCF5hBtOMnQA==" is different than host(s): node9,node3

It now looks like:

     node9
       ECOM1: /etc/ceph/ceph.conf does not exist
       ECOM2: ceph executable was not found in common paths when running `which`
       ECOM3: /var/lib/ceph could not be parsed: [Errno 2] No such file or directory: '/var/lib/ceph'
       EMON1: secret key "None" is different than host(s): mira049,mira060,mira021
     mira049
       WMON2: collocated OSDs found: ceph-40,ceph-46,ceph-49,ceph-7,ceph-8,ceph-12,ceph-18
       EMON1: secret key "AQCRWAtSAAAAABAAtLVEZ9qH0MLCF5hBtOMnQA==" is different than host(s): node9,node3
     mira060
       WMON2: collocated OSDs found: ceph-1,ceph-69,ceph-25,ceph-26,ceph-27,ceph-22,ceph-23,ceph-10,ceph-66,ceph-74
       EMON1: secret key "AQCRWAtSAAAAABAAtLVEZ9qH0MLCF5hBtOMnQA==" is different than host(s): node9,node3
     node3
       WMON2: collocated OSDs found: ceph-5
       EMON1: secret key "None" is different than host(s): mira049,mira060,mira021
     mira021
       WMON2: collocated OSDs found: ceph-5,ceph-6,ceph-11,ceph-15,ceph-17,ceph-19,ceph-20
       EMON1: secret key "AQCRWAtSAAAAABAAtLVEZ9qH0MLCF5hBtOMnQA==" is different than host(s): node9,node3

Added a couple of tests, mainly paving the way to get more tests going, with fixtures that will help mangle the data collected to trigger errors