### PR TITLE
tests: update config to match latest ceph-ansible

### DIFF
--- a/tests/functional/centos7/group_vars/all
+++ b/tests/functional/centos7/group_vars/all
@@ -1,6 +1,8 @@
 ---
 
-ceph_stable: True
+ceph_origin: repository
+ceph_repository: community
+ceph_stable_release: luminous
 cluster: test
 public_network: "192.168.3.0/24"
 cluster_network: "192.168.4.0/24"
@@ -10,7 +12,7 @@ osd_objectstore: "filestore"
 devices:
   - '/dev/sda'
   - '/dev/sdb'
-journal_collocation: True
+osd_scenario: collocated
 os_tuning_params:
   - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }


### PR DESCRIPTION
Our config for the test cluster needs updated to match the latest
changes to osd scenarios and install config options in ceph-ansible.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>