### PR TITLE
debian: Build-Depends test suite dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,9 @@ Build-Depends:
  debhelper (>= 7),
  dh-python,
  python,
+ python-mock,
  python-pytest,
+ python-remoto,
  python-setuptools,
  python-tambo
 X-Python-Version: >= 2.7


### PR DESCRIPTION
The test suite fails to run in pbuilder without these.