### PR TITLE
adds a check for parity between installed and socket versions

### DIFF
--- a/ceph_medic/checks/common.py
+++ b/ceph_medic/checks/common.py
@@ -86,3 +86,18 @@ def check_ceph_version_parity(host, data):
 
     if mismatched_hosts:
         return code, msg % (host_version, ','.join(mismatched_hosts))
+
+
+def check_ceph_socket_and_installed_version_parity(host, data):
+    code = 'ECOM7'
+    msg = '(installed) Ceph version "%s" is different than version from running socket(s): %s'
+    mismatched_sockets = []
+    host_version = data['ceph']['version']
+    sockets = data['ceph']['sockets']
+    for socket, socket_data in sockets.items():
+        socket_version = socket_data.get('version')
+        if socket_version and socket_version != host_version:
+            mismatched_sockets.append("%s:%s" % (socket, socket_version))
+
+    if mismatched_sockets:
+        return code, msg % (host_version, ','.join(mismatched_sockets))

--- a/ceph_medic/checks/common.py
+++ b/ceph_medic/checks/common.py
@@ -96,7 +96,7 @@ def check_ceph_socket_and_installed_version_parity(host, data):
     sockets = data['ceph']['sockets']
     for socket, socket_data in sockets.items():
         socket_version = socket_data.get('version')
-        if socket_version and socket_version != host_version:
+        if socket_version and socket_version not in host_version:
             mismatched_sockets.append("%s:%s" % (socket, socket_version))
 
     if mismatched_sockets:

--- a/ceph_medic/tests/checks/test_common.py
+++ b/ceph_medic/tests/checks/test_common.py
@@ -90,10 +90,10 @@ class TestCephSocketAndInstalledVersionParity(object):
         node1_data = make_data(
             {'ceph': {
                 "sockets": {
-                    "/var/run/ceph/osd.asok": {"version": "12.2.1"},
+                    "/var/run/ceph/osd.asok": {"version": "12.2.0"},
                 },
                 "installed": True,
-                "version": "12.2.1",
+                "version": "ceph version 12.2.0 (32ce2a3ae5239ee33d6150705cdb24d43bab910c) luminous (rc)",
             }}
         )
         metadata['mons']['node1'] = node1_data

--- a/ceph_medic/tests/checks/test_common.py
+++ b/ceph_medic/tests/checks/test_common.py
@@ -60,3 +60,42 @@ class TestCephVersionParity(object):
         metadata['mons']['node2'] = make_data()
         result = common.check_ceph_version_parity('node1', node1_data)
         assert result is None
+
+
+class TestCephSocketAndInstalledVersionParity(object):
+
+    def setup(self):
+        metadata['cluster_name'] = 'ceph'
+
+    def teardown(self):
+        metadata.pop('cluster_name')
+
+    def test_finds_a_mismatch_of_versions(self, make_nodes, make_data):
+        metadata['nodes'] = make_nodes(mons=['node1'])
+        node1_data = make_data(
+            {'ceph': {
+                "sockets": {
+                    "/var/run/ceph/osd.asok": {"version": "13.2.0"},
+                },
+                "installed": True,
+                "version": "12.2.1",
+            }}
+        )
+        metadata['mons']['node1'] = node1_data
+        result = common.check_ceph_socket_and_installed_version_parity('node1', node1_data)
+        assert 'Ceph version "12.2.1" is different' in str(result)
+
+    def test_versions_have_parity(self, make_nodes, make_data):
+        metadata['nodes'] = make_nodes(mons=['node1'])
+        node1_data = make_data(
+            {'ceph': {
+                "sockets": {
+                    "/var/run/ceph/osd.asok": {"version": "12.2.1"},
+                },
+                "installed": True,
+                "version": "12.2.1",
+            }}
+        )
+        metadata['mons']['node1'] = node1_data
+        result = common.check_ceph_socket_and_installed_version_parity('node1', node1_data)
+        assert result is None

--- a/ceph_medic/tests/checks/test_common.py
+++ b/ceph_medic/tests/checks/test_common.py
@@ -99,3 +99,18 @@ class TestCephSocketAndInstalledVersionParity(object):
         metadata['mons']['node1'] = node1_data
         result = common.check_ceph_socket_and_installed_version_parity('node1', node1_data)
         assert result is None
+
+    def test_socket_version_is_none(self, make_nodes, make_data):
+        metadata['nodes'] = make_nodes(mons=['node1'])
+        node1_data = make_data(
+            {'ceph': {
+                "sockets": {
+                    "/var/run/ceph/osd.asok": {},
+                },
+                "installed": True,
+                "version": "12.2.1",
+            }}
+        )
+        metadata['mons']['node1'] = node1_data
+        result = common.check_ceph_socket_and_installed_version_parity('node1', node1_data)
+        assert result is None

--- a/docs/source/codes/common.rst
+++ b/docs/source/codes/common.rst
@@ -8,43 +8,45 @@ Errors
 .. _ECOM1:
 
 ECOM1
-_____
+^^^^^
 A ceph configuration file can not be found at ``/etc/ceph/$cluster-name.conf``.
 
 .. _ECOM2:
 
 ECOM2
-_____
+^^^^^
 The ``ceph`` executable was not found.
 
 .. _ECOM3:
 
 ECOM3
-_____
+^^^^^
 The ``/var/lib/ceph`` directory does not exist or could not be collected.  
 
 .. _ECOM4:
 
 ECOM4
-_____
+^^^^^
 The ``/var/lib/ceph`` directory was not owned by the ``ceph`` user. 
 
 .. _ECOM5:
 
 ECOM5
-_____
+^^^^^
 The ``fsid`` defined in the configuration differs from other nodes in the cluster. The ``fsid`` must be
 the same for all nodes in the cluster.
 
 .. _ECOM6:
 
 ECOM6
-_____
+^^^^^
 The installed version of ``ceph`` is not the same for all nodes in the cluster. The ``ceph`` version should be
 the same for all nodes in the cluster.
 
+.. _ECOM7:
+
 ECOM7
-_____
+^^^^^
 The installed version of ``ceph`` is not the same reported by a running ceph daemon. The installed ``ceph`` version should be
 the same as all running ceph daemons, if they do not match these daemons most likely have not been restarted correctly after
 a version change.

--- a/docs/source/codes/common.rst
+++ b/docs/source/codes/common.rst
@@ -42,3 +42,9 @@ ECOM6
 _____
 The installed version of ``ceph`` is not the same for all nodes in the cluster. The ``ceph`` version should be
 the same for all nodes in the cluster.
+
+ECOM7
+_____
+The installed version of ``ceph`` is not the same reported by a running ceph daemon. The installed ``ceph`` version should be
+the same as all running ceph daemons, if they do not match these daemons most likely have not been restarted correctly after
+a version change.


### PR DESCRIPTION
Fixes: https://github.com/ceph/ceph-medic/issues/65