### PR TITLE
Fix typo in osds.py when checking pool default min_size

### DIFF
--- a/ceph_medic/checks/osds.py
+++ b/ceph_medic/checks/osds.py
@@ -36,7 +36,7 @@ def check_osd_ceph_fsid(host, data):
 
 def check_min_pool_size(host, data):
     code = 'WOSD2'
-    msg = 'osd default pool size is set to 1, can potentially lose data'
+    msg = 'osd default pool min_size is set to 1, can potentially lose data'
     conf = get_ceph_conf(data)
     size = conf.get_safe('global', 'osd_pool_default_min_size', '0')
     if int(size) == 1:

--- a/ceph_medic/tests/checks/test_osds.py
+++ b/ceph_medic/tests/checks/test_osds.py
@@ -28,7 +28,7 @@ class TestOSDS(object):
         osd_data = data()
         osd_data['paths']['/etc/ceph']['files']['/etc/ceph/ceph.conf'] = {'contents': contents}
         code, error = osds.check_min_pool_size(None, osd_data)
-        assert error == 'osd default pool size is set to 1, can potentially lose data'
+        assert error == 'osd default pool min_size is set to 1, can potentially lose data'
 
     def test_min_pool_size_is_correct(self, data):
         contents = dedent("""


### PR DESCRIPTION
Although the min_size check is correct, the message displayed on screen is incorrect. 

Changing from "osd default pool size is set to 1" to "osd default pool min_size is set to 1"