### PR TITLE
tests increase the ssh retries from 0 to 5

### DIFF
--- a/tests/functional/tox.ini
+++ b/tests/functional/tox.ini
@@ -12,6 +12,7 @@ setenv=
   ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config
   ansible2.2: ANSIBLE_STDOUT_CALLBACK = debug
   ANSIBLE_RETRY_FILES_ENABLED = False
+  ANSIBLE_SSH_RETRIES = 5
 deps=
   ansible1.9: ansible==1.9.4
   ansible2.1: ansible==2.1


### PR DESCRIPTION
Fixes this issue when running tests:

    fatal: [osd0]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh: ", "unreachable": true}