### PR TITLE
tests: install notario when running functional tests

### DIFF
--- a/tests/functional/tox.ini
+++ b/tests/functional/tox.ini
@@ -19,6 +19,7 @@ deps=
   ansible2.1: ansible==2.1
   ansible2.2: ansible==2.2.3
   ansible2.3: ansible==2.3.1
+  notario>=0.0.13
 changedir=
   nightly_centos7: {toxinidir}/centos7
 commands=

--- a/tests/functional/tox.ini
+++ b/tests/functional/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {ansible2.2,ansible2.3}-{nightly_centos7}
+envlist = {ansible2.2,ansible2.3,ansible2.4}-{nightly_centos7}
 skipsdist = True
 
 [testenv]
@@ -19,6 +19,7 @@ deps=
   ansible2.1: ansible==2.1
   ansible2.2: ansible==2.2.3
   ansible2.3: ansible==2.3.1
+  ansible2.4: ansible==2.4.2
   notario>=0.0.13
 changedir=
   nightly_centos7: {toxinidir}/centos7


### PR DESCRIPTION
ceph-ansible now requires this library for config validation. This also adds an ``ansible2.4`` factor.