### PR TITLE
kubernetes and openshift support

### DIFF
--- a/ceph_medic/__init__.py
+++ b/ceph_medic/__init__.py
@@ -1,3 +1,19 @@
+
+
+# TODO: make this nicer for a file-based loaded config
+#class UnloadedConfig(object):
+#    """
+#    This class is used as the default value for config.ceph so that if
+#    a configuration file is not successfully loaded then it will give
+#    a nice error message when values from the config are used.
+#    """
+#    def __getattr__(self, *a):
+#        raise RuntimeError("No valid ceph configuration file was loaded.")
+#
+#
+#config = namedtuple('config', ['verbosity', 'nodes', 'hosts_file', 'file'])
+#conf.file = UnloadedConfig()
+
 config = {
     'verbosity': 'info',
     'nodes': {},

--- a/ceph_medic/collector.py
+++ b/ceph_medic/collector.py
@@ -183,11 +183,14 @@ def collect():
                 loader.write('Host: %-20s  connection: [%-20s]' % (hostname, terminal.red('failed')))
                 loader.write('\n')
                 failed_nodes += 1
+                if metadata[node_type].get(hostname):
+                    metadata[node_type].pop(hostname)
+                metadata['nodes'][node_type] = [i for i in metadata['nodes'][node_type] if i['host'] != hostname]
                 continue
 
             # send the full node metadata for global scope so that the checks
             # can consume this
-            metadata[node_type][node['host']] = get_node_metadata(conn, hostname, cluster_nodes)
+            metadata[node_type][hostname] = get_node_metadata(conn, hostname, cluster_nodes)
             conn.exit()
     if failed_nodes == total_nodes:
         loader.write(terminal.red('Collection failed!') + ' ' *70)
@@ -195,6 +198,8 @@ def collect():
         # clean, but this manual clearing should be done automatically
         terminal.write.raw('')
         raise RuntimeError('All nodes failed to connect. Cannot run any checks')
+    if failed_nodes:
+        loader.write('Collection completed with some failed connections' + ' ' *70 + '\n')
     else:
         loader.write('Collection completed!' + ' ' *70 + '\n')
 

--- a/ceph_medic/collector.py
+++ b/ceph_medic/collector.py
@@ -190,7 +190,10 @@ def collect():
             metadata[node_type][node['host']] = get_node_metadata(conn, hostname, cluster_nodes)
             conn.exit()
     if failed_nodes == total_nodes:
-        loader.write(terminal.red('Collection failed!') + ' ' *70 + '\n')
+        loader.write(terminal.red('Collection failed!') + ' ' *70)
+        # TODO: this helps clear out the 'loader' line so that the error looks
+        # clean, but this manual clearing should be done automatically
+        terminal.write.raw('')
         raise RuntimeError('All nodes failed to connect. Cannot run any checks')
     else:
         loader.write('Collection completed!' + ' ' *70 + '\n')

--- a/ceph_medic/connection.py
+++ b/ceph_medic/connection.py
@@ -22,18 +22,23 @@ def get_connection(hostname, username=None, threads=5, use_sudo=None, detect_sud
     if ceph_medic.config.get('ssh_config'):
         hostname = "-F %s %s" % (ceph_medic.config.get('ssh_config'), hostname)
     try:
-
-        conn = remoto.Connection(
-            hostname,
-            logger=remote_logger,
-            threads=threads,
-            detect_sudo=detect_sudo,
-        )
+        deployment_type = ceph_medic.config.get('deployment_type', 'ssh')
+        conn_obj = remoto.connection.get(deployment_type)
+        # TODO: generalize this out of here
+        if deployment_type in ['k8s', 'kubernetes']:
+            namespace = ceph_medic.config['file'].get_safe('kubernetes', 'namespace', 'rook-ceph')
+            conn = conn_obj(hostname, namespace)
+        elif deployment_type in ['ssh', 'baremetal']:
+            conn = conn_obj(
+                hostname,
+                logger=remote_logger,
+                threads=threads,
+                detect_sudo=detect_sudo,
+            )
 
         # Set a timeout value in seconds to disconnect and move on
         # if no data is sent back.
         conn.global_timeout = 300
-
         # XXX put this somewhere else
         if not ceph_medic.config['cluster_name']:
             cluster_conf_files, stderr, exit_code = remoto.process.check(conn, ['ls', '/etc/ceph/'])
@@ -54,6 +59,16 @@ def get_connection(hostname, username=None, threads=5, use_sudo=None, detect_sud
         logger.error(msg)
         logger.error(errors)
         raise error
+
+
+def as_bytes(string):
+    """
+    Ensure that whatever type of string is incoming, it is returned as bytes,
+    encoding to utf-8 otherwise
+    """
+    if isinstance(string, bytes):
+        return string
+    return string.encode('utf-8', errors='ignore')
 
 
 def get_local_connection(logger, use_sudo=False):

--- a/ceph_medic/decorators.py
+++ b/ceph_medic/decorators.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from ceph_medic import terminal
 from functools import wraps
@@ -44,6 +45,8 @@ def catches(catch=None, handler=None, exit=True):
             try:
                 return f(*a, **kw)
             except catch as e:
+                if os.environ.get('CEPH_MEDIC_DEBUG'):
+                    raise
                 if handler:
                     return handler(e)
                 else:

--- a/ceph_medic/generate.py
+++ b/ceph_medic/generate.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys
 import ceph_medic
 from ceph_medic.connection import get_connection
@@ -27,7 +28,7 @@ def generate_inventory(inventory, to_stdout=False, tmp_dir=None):
     result_str = "\n".join(result) + "\n"
     # if not None the NamedTemporaryFile will be created in the given directory
     if to_stdout:
-        print result_str
+        print(result_str)
         return
     with open('hosts_file', 'w') as hosts_file:
         hosts_file.write(result_str)
@@ -44,7 +45,7 @@ def get_mon_report(conn):
 
     if code > 0:
         for line in err:
-            print line
+            print(line)
 
     try:
         return json.loads(b''.join(out).decode('utf-8'))

--- a/ceph_medic/main.py
+++ b/ceph_medic/main.py
@@ -1,11 +1,14 @@
 from ceph_medic import check, log
+import json
 import sys
 import os
 from textwrap import dedent
 from tambo import Transport
+import remoto
 from execnet.gateway_bootstrap import HostNotFound
 import ceph_medic
 from ceph_medic.decorators import catches
+from ceph_medic.generate import generate_inventory
 from ceph_medic.util import configuration
 from ceph_medic import terminal
 
@@ -103,6 +106,7 @@ Global Options:
         log.setup(loaded_config)
         # update the module-wide configuration object
         ceph_medic.config.update(configuration.get_overrides(loaded_config))
+        ceph_medic.config['file'] = loaded_config
 
         # SSH config
         ceph_medic.config['ssh_config'] = parser.get('--ssh-config')
@@ -115,18 +119,28 @@ Global Options:
         ceph_medic.config['cluster_name'] = parser.get('--cluster')
         ceph_medic.metadata['cluster_name'] = 'ceph'
 
-        # Hosts file
-        self.hosts_file = parser.get('--inventory', configuration.get_host_file())
+        # XXX Can't be if/else through all the connections possible here,
+        # generlize, get a helper, cleanup
+        # Deployment Type
+        if ceph_medic.config['file'].get_safe('global', 'deployment_type') == 'kubernetes':
+            k8s_hosts = generate_k8s_hosts()
+            ceph_medic.config['nodes'] = k8s_hosts
+            ceph_medic.config['hosts_file'] = ':memory:'
+            self.hosts_file = ':memory:'
 
-        # find the hosts files, by the CLI first, fallback to the configuration
-        # file, and lastly if none of those are found or defined, try to load
-        # from well known locations (cwd, and /etc/ansible/)
-        loaded_hosts = configuration.load_hosts(
-            parser.get('--inventory',
-                       ceph_medic.config.get('--inventory', self.hosts_file)))
-        ceph_medic.config['nodes'] = loaded_hosts.nodes
-        ceph_medic.config['hosts_file'] = loaded_hosts.filename
-        self.hosts_file = loaded_hosts.filename
+        else:
+            # Hosts file
+            self.hosts_file = parser.get('--inventory', configuration.get_host_file())
+
+            # find the hosts files, by the CLI first, fallback to the configuration
+            # file, and lastly if none of those are found or defined, try to load
+            # from well known locations (cwd, and /etc/ansible/)
+            loaded_hosts = configuration.load_hosts(
+                parser.get('--inventory',
+                           ceph_medic.config.get('--inventory', self.hosts_file)))
+            ceph_medic.config['nodes'] = loaded_hosts.nodes
+            ceph_medic.config['hosts_file'] = loaded_hosts.filename
+            self.hosts_file = loaded_hosts.filename
 
         parser.catch_version = ceph_medic.__version__
         parser.mapper = self.mapper
@@ -137,3 +151,40 @@ Global Options:
         parser.dispatch()
         parser.catches_help()
         parser.catches_version()
+
+
+# TODO: get this out of here, generalize, cleanup
+def generate_k8s_hosts():
+    namespace = ceph_medic.config['file'].get_safe('kubernetes', 'namespace', 'rook-ceph')
+    local_conn = remoto.connection.get('local')()
+    cmd = ['kubectl', '--request-timeout=5', '-n', namespace, 'get', 'pods', '-o', 'json']
+    out, err, code = remoto.process.check(local_conn, cmd)
+    if code:
+        terminal.error('Unable to retrieve the pods via kubectl using command: %s' % ' '.join(cmd))
+        raise SystemExit('\n'.join(err))
+    pods = json.loads(''.join(out))
+    base_inventory = {
+        'rgws': [], 'mgrs': [], 'mdss': [], 'clients': [], 'osds': [], 'mons': []
+    }
+    label_map = {
+        'rook-ceph-mgr': 'mgrs',
+        'rook-ceph-mon': 'mons',
+        'rook-ceph-osd': 'osds',
+        'rook-ceph-mds': 'mdss',
+        'rook-ceph-rgw': 'rgws',
+        'rook-ceph-client': 'clients',
+    }
+
+    for item in pods['items']:
+        label_name = item['metadata'].get('labels', {}).get('app')
+        if not label_name:
+            continue
+        if label_name in label_map:
+            inventory_key = label_map[label_name]
+            base_inventory[inventory_key].append(
+                {'host': item['metadata']['name'], 'group': None}
+            )
+    for key, value in dict(base_inventory).items():
+        if not value:
+            base_inventory.pop(key)
+    return base_inventory

--- a/ceph_medic/remote/functions.py
+++ b/ceph_medic/remote/functions.py
@@ -56,8 +56,14 @@ def stat_path(path, skip_dirs=None, skip_files=None, get_contents=False):
             metadata[attr] = value
 
     # translate the owner and group:
-    metadata[u'owner'] = decoded(pwd.getpwuid(stat_info.st_uid)[0])
-    metadata[u'group'] = decoded(grp.getgrgid(stat_info.st_gid)[0])
+    try:
+        metadata[u'owner'] = decoded(pwd.getpwuid(stat_info.st_uid)[0])
+    except KeyError:
+        metadata[u'owner'] = stat_info.st_uid
+    try:
+        metadata[u'group'] = decoded(grp.getgrgid(stat_info.st_gid)[0])
+    except KeyError:
+        metadata[u'group'] = stat_info.st_gid
 
     return metadata
 

--- a/ceph_medic/remote/functions.py
+++ b/ceph_medic/remote/functions.py
@@ -20,6 +20,13 @@ def capture_exception(error):
     return details
 
 
+def decoded(string):
+    try:
+        return string.decode('utf-8')
+    except AttributeError:
+        return string
+
+
 # Paths
 #
 def stat_path(path, skip_dirs=None, skip_files=None, get_contents=False):
@@ -31,24 +38,26 @@ def stat_path(path, skip_dirs=None, skip_files=None, get_contents=False):
     # .. note:: Neither ``skip_dirs`` nor ``skip_files`` is used here, but the
     # remote execution of functions use name-based arguments which does not allow
     # the use of ``**kw``
-
-    metadata = {'exception': {}}
+    metadata = {u'exception': {}}
+    path = decoded(path)
     try:
         stat_info = os.stat(path)
         if get_contents and os.path.isfile(path):
             with open(path, 'r') as opened_file:
-                metadata['contents'] = opened_file.read()
+                metadata[u'contents'] = decoded(opened_file.read())
     except Exception as error:
         return {'exception': capture_exception(error)}
 
     # get all the stat results back into the metadata
     for attr in dir(stat_info):
+        attr = decoded(attr)
         if not attr.startswith('__'):
-            metadata[attr] = getattr(stat_info, attr)
+            value = decoded(getattr(stat_info, attr))
+            metadata[attr] = value
 
     # translate the owner and group:
-    metadata['owner'] = pwd.getpwuid(stat_info.st_uid)[0]
-    metadata['group'] = grp.getgrgid(stat_info.st_gid)[0]
+    metadata[u'owner'] = decoded(pwd.getpwuid(stat_info.st_uid)[0])
+    metadata[u'group'] = decoded(grp.getgrgid(stat_info.st_gid)[0])
 
     return metadata
 
@@ -68,7 +77,10 @@ def path_tree(path, skip_dirs=None, skip_files=None, get_contents=None):
 
     # .. note:: ``get_contents`` is not used here, but the remote execution of functions
     # use name-based arguments which does not allow the use of ``**kw``
-
+    try:
+        path = path.decode('utf-8')
+    except AttributeError:
+        pass
     skip_files = skip_files or []
     skip_dirs = skip_dirs or []
     files = []
@@ -87,7 +99,11 @@ def path_tree(path, skip_dirs=None, skip_files=None, get_contents=None):
             absolute_path = os.path.join(root, _dir)
             dirs.append(absolute_path)
 
-    return dict(path=path, dirs=dirs, files=files)
+    # using the 'u' prefix forces python3<->python2 compatibility otherwise the
+    # keys would be bytes, regardless if input is a str which should've forced
+    # a 'str' behavior. The prefix is invalid syntax for Python 3.0 to 3.2, so
+    # this will be valid in Python 3.3 and newer and Python 2
+    return {u'path': path, u'dirs': dirs, u'files': files}
 
 
 def which(executable):

--- a/ceph_medic/runner.py
+++ b/ceph_medic/runner.py
@@ -1,6 +1,7 @@
 import logging
 from ceph_medic import metadata, terminal, daemon_types
 from ceph_medic import checks, __version__
+from ceph_medic import config
 
 logger = logging.getLogger(__name__)
 
@@ -115,7 +116,8 @@ def report(results):
 
 start_header_tmpl = """
 {title:=^80}
-Version: {version: >4}    Cluster Name: "{cluster_name}"
+Version:    {version: >4}    Cluster Name: "{cluster_name}"
+Connection: {connection_type}
 Total hosts: [{total_hosts}]
 OSDs: {osds: >4}    MONs: {mons: >4}     Clients: {clients: >4}
 MDSs: {mdss: >4}    RGWs: {rgws: >4}     MGRs: {mgrs: >7}
@@ -123,6 +125,7 @@ MDSs: {mdss: >4}    RGWs: {rgws: >4}     MGRs: {mgrs: >7}
 
 
 def start_header():
+    connection_type = config['file'].get_safe('global', 'deployment_type', 'ssh')
     daemon_totals = dict((daemon, 0) for daemon in daemon_types)
     total_hosts = 0
     for daemon in daemon_types:
@@ -132,6 +135,7 @@ def start_header():
     terminal.write.raw(start_header_tmpl.format(
         title='  Starting remote check session  ',
         version=__version__,
+        connection_type=connection_type,
         total_hosts=total_hosts,
         cluster_name=metadata['cluster_name'],
         **daemon_totals))

--- a/ceph_medic/util/configuration.py
+++ b/ceph_medic/util/configuration.py
@@ -38,6 +38,9 @@ medic_conf_template = """
 # Should always be an absolute path, although '.' is allowed to log from
 # wherever the CLI is executed from (current working directory)
 --log-path = .
+# What type of deployment is the cluster using? Valid values are:
+# baremetal, container, openshift, kubernetes
+# deployment_type = baremetal
 
 [check]
 # Overrides for some of ceph-medic's check flags, like what errors or warnings
@@ -45,6 +48,11 @@ medic_conf_template = """
 # should be comma separated into their respective codes.
 # --ignore = ECOMM101,ECOMM102
 
+[baremetal]
+# baremetal options
+
+[kubernetes]
+namespace = rook-ceph
 """
 
 

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ class ReleaseCommand(Command):
         print(' '.join(cmd))
         subprocess.check_call(cmd)
 
+
 setup(
     name='ceph-medic',
     version=version,
@@ -108,7 +109,7 @@ setup(
     install_requires=[
         'execnet',
         'tambo',
-        'remoto',
+        'remoto>=1.1.0',
     ] + install_requires,
 
     tests_require=[

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, flake8
+envlist = py27, py36, flake8
 
 [testenv]
 deps=


### PR DESCRIPTION
This brings full support for openshift and kubernetes checks to ceph-medic. We are able to dynamically generate the hosts to connect to, and provide the same experience as baremetal-provisioned hosts.

There is quite a bit to update and clean up, but wanted to get this PR out, and follow up with docs and clean up (see `XXX` and `TODO`s)