### PR TITLE
check: set a non-zero exit status on errors, warnings, or failures

### DIFF
--- a/ceph_medic/check.py
+++ b/ceph_medic/check.py
@@ -66,3 +66,8 @@ Configured Nodes:
         test = runner.Runner()
         results = test.run()
         runner.report(results)
+        #XXX might want to make this configurable to not bark on warnings for
+        # example, setting forcefully for now, but the results object doesn't
+        # make a distinction between error and warning (!)
+        if results.errors or results.failed:
+            sys.exit(1)


### PR DESCRIPTION
Fixes issue #95 