### PR TITLE
Separate warnings and errors from failures

### DIFF
--- a/ceph_medic/check.py
+++ b/ceph_medic/check.py
@@ -69,5 +69,5 @@ Configured Nodes:
         #XXX might want to make this configurable to not bark on warnings for
         # example, setting forcefully for now, but the results object doesn't
         # make a distinction between error and warning (!)
-        if results.errors or results.failed:
+        if results.errors or results.warnings:
             sys.exit(1)

--- a/ceph_medic/tests/test_runner.py
+++ b/ceph_medic/tests/test_runner.py
@@ -38,14 +38,46 @@ class TestReport(object):
         runner.metadata['nodes'] = {}
         self.results = runner.Runner()
 
-    def test_reports_errors(self, terminal):
-        self.results.errors = ['I am an error']
+    def test_reports_internal_errors(self, terminal):
+        self.results.internal_errors = ['I am an error']
         runner.report(self.results)
-        assert 'While running checks, ceph-medic had unhandled errors' in terminal.calls[-1]
+        assert 'While running checks, ceph-medic had 1 unhandled errors' in terminal.calls[-1]
 
     def test_reports_no_errors(self, terminal):
         runner.report(self.results)
         assert terminal.calls[0] == '\n0 passed, on 0 hosts'
+
+    def test_reports_warning(self, terminal):
+        self.results.warnings = 1
+        runner.report(self.results)
+        assert terminal.calls[0] == '\n0 passed, 1 warning, on 0 hosts'
+
+    def test_reports_warnings(self, terminal):
+        self.results.warnings = 2
+        runner.report(self.results)
+        assert terminal.calls[0] == '\n0 passed, 2 warnings, on 0 hosts'
+
+    def test_reports_error(self, terminal):
+        self.results.errors = 1
+        runner.report(self.results)
+        assert terminal.calls[0] == '\n0 passed, 1 error, on 0 hosts'
+
+    def test_reports_errors(self, terminal):
+        self.results.errors = 2
+        runner.report(self.results)
+        assert terminal.calls[0] == '\n0 passed, 2 errors, on 0 hosts'
+
+    def test_reports_error_and_warning(self, terminal):
+        self.results.errors = 1
+        self.results.warnings = 1
+        runner.report(self.results)
+        assert terminal.calls[0] == '\n0 passed, 1 error, 1 warning, on 0 hosts'
+
+    def test_reports_errors_and_warnings(self, terminal):
+        self.results.errors = 2
+        self.results.warnings = 2
+        runner.report(self.results)
+        assert terminal.calls[0] == '\n0 passed, 2 errors, 2 warnings, on 0 hosts'
 
 
 class TestReportBasicOutput(object):


### PR DESCRIPTION
Fixes issue #101 by separating errors and warnings from the "failed" bucket. This removes `failed` as it will be possible in the future to not _fail_ on anything or fail on warnings for example. The wording will not be able to keep up with the configuration, so `failed` is removed, and we limit the reporting on warnings, errors, and internal errors.