### PR TITLE
Error on collocated mons with OSDs

### DIFF
--- a/ceph_medic/checks/common.py
+++ b/ceph_medic/checks/common.py
@@ -56,6 +56,26 @@ def get_host_fsids(node_metadata):
 
 
 #
+# Warning checks
+#
+
+def check_colocated_running_mons_osds(host, data):
+    code = 'WCOM1'
+    msg = 'collocated OSDs with MONs running: %s'
+    sockets = data['ceph']['sockets']
+    running_mons = []
+    running_osds = []
+    for socket_name in sockets.keys():
+        if "mon." in socket_name:
+            running_mons.append(socket_name)
+        elif "osd." in socket_name:
+            running_osds.append(socket_name)
+    if running_mons and running_osds:
+        daemons = "\n    %s" % ','.join(running_osds)
+        return code, msg % daemons
+
+
+#
 # Error checks
 #
 
@@ -204,3 +224,15 @@ def check_fsid_per_daemon(host, data):
             failed = True
     if failed:
         return code, msg
+
+
+def check_multiple_running_mons(host, data):
+    code = 'ECOM10'
+    msg = 'multiple running mons found: %s'
+    sockets = data['ceph']['sockets']
+    running_mons = []
+    for socket_name in sockets.keys():
+        if "mon." in socket_name:
+            running_mons.append(socket_name)
+    if len(running_mons) > 1:
+        return code, msg % ','.join(running_mons)

--- a/ceph_medic/collector.py
+++ b/ceph_medic/collector.py
@@ -78,7 +78,7 @@ def collect_paths(conn):
         "/var/lib/ceph": {
             'get_contents': True,
             'skip_files': ['activate.monmap', 'superblock'],
-            'skip_dirs': ['current', 'store.db']
+            'skip_dirs': ['tmp', 'current', 'store.db']
         },
         "/var/run/ceph": {'get_contents': False},
     }

--- a/ceph_medic/tests/conftest.py
+++ b/ceph_medic/tests/conftest.py
@@ -57,7 +57,7 @@ def data():
     """
     def _data():
         return {
-            'ceph': {'installed': True, 'version': '12.2.1'},
+            'ceph': {'installed': True, 'version': '12.2.1', 'sockets':{}},
             'paths': {
                 '/etc/ceph': {'files': {}, 'dirs': {}},
                 '/var/lib/ceph': {'files': {}, 'dirs': {}},

--- a/docs/source/codes/common.rst
+++ b/docs/source/codes/common.rst
@@ -2,6 +2,16 @@ Common
 ======
 The following checks indiciate general issues with the cluster that are not specific to any daemon type.
 
+Warnings
+--------
+
+.. _WCOM1:
+
+WCOM1
+^^^^^
+A running OSD and MON daemon was detected in the same node. Colocating OSDs and MONs is highly discouraged.
+
+
 Errors
 ------
 
@@ -21,13 +31,13 @@ The ``ceph`` executable was not found.
 
 ECOM3
 ^^^^^
-The ``/var/lib/ceph`` directory does not exist or could not be collected.  
+The ``/var/lib/ceph`` directory does not exist or could not be collected.
 
 .. _ECOM4:
 
 ECOM4
 ^^^^^
-The ``/var/lib/ceph`` directory was not owned by the ``ceph`` user. 
+The ``/var/lib/ceph`` directory was not owned by the ``ceph`` user.
 
 .. _ECOM5:
 
@@ -56,3 +66,17 @@ a version change.
 ECOM8
 ^^^^^
 The ``fsid`` field must exist in the configuration for each node.
+
+
+.. _ECOM9:
+
+ECOM9
+^^^^^
+A cluster should not have running daemons with a cluster ``fsid`` that is different from the rest of the daemons in a cluster. This can potentially mean that different cluster identifiers are being used, and that shouldn't be the case.
+
+
+.. _ECOM10:
+
+ECOM10
+^^^^^^
+Only a single monitor daemon shuld be running per host, having more than one monitor running on the same host reduces a cluster's resilience if the node goes down.


### PR DESCRIPTION
These are now caught in the `common` module, so that regardless of the host type (mon or osd) it will report the problem.

Finishes the fixes needed for #30 
Fixes: #110 which was causing breakage due to a monmap in /var/lib/ceph/tmp

