### PR TITLE
codes: actually be able to ignore them

### DIFF
--- a/ceph_medic/check.py
+++ b/ceph_medic/check.py
@@ -7,6 +7,18 @@ from tambo import Transport
 logger = logging.getLogger(__name__)
 
 
+def as_list(string):
+    if not string:
+        return []
+    string = string.strip(',')
+
+    # split on commas
+    string = string.split(',')
+
+    # strip spaces
+    return [x.strip() for x in string]
+
+
 class Check(object):
     help = "Run checks for all the configured nodes in a cluster or hosts file"
     long_help = """
@@ -45,13 +57,18 @@ Configured Nodes:
 
     def main(self):
         options = ['--ignore']
+        config_ignores = ceph_medic.config.file.get_list('check', '--ignore')
         parser = Transport(
             self.argv, options=options,
             check_version=False
         )
         parser.catch_help = self._help()
         parser.parse_args()
-        ignored_codes = parser.get('--ignore', '').strip().strip(',').split(',')
+        ignored_codes = as_list(parser.get('--ignore', ''))
+        # fallback to the configuration if nothing is defined in the CLI
+        if not ignored_codes:
+            ignored_codes = config_ignores
+
         if len(self.argv) < 1:
             return parser.print_help()
 

--- a/ceph_medic/check.py
+++ b/ceph_medic/check.py
@@ -50,8 +50,8 @@ Configured Nodes:
             check_version=False
         )
         parser.catch_help = self._help()
-
         parser.parse_args()
+        ignored_codes = parser.get('--ignore', '').strip().strip(',').split(',')
         if len(self.argv) < 1:
             return parser.print_help()
 
@@ -64,6 +64,7 @@ Configured Nodes:
 
         collector.collect()
         test = runner.Runner()
+        test.ignore = ignored_codes
         results = test.run()
         runner.report(results)
         #XXX might want to make this configurable to not bark on warnings for

--- a/ceph_medic/remote/functions.py
+++ b/ceph_medic/remote/functions.py
@@ -16,7 +16,15 @@ def capture_exception(error):
     details['traceback'] = ''.join(traceback.format_exception(exc_type, exc_value, exc_traceback))
     for attr in dir(error):
         if not attr.startswith('__'):
-            details['attributes'][attr] = getattr(error, attr)
+            try:
+                details['attributes'][attr] = str(getattr(error, attr))
+            except Exception:
+                # getting an exception here is entirely possible, and since
+                # there is no remote logging there is nothing we can do other
+                # than eat it up. This section is going through each of the
+                # attributes of the exception raised so it is mildly acceptable
+                # to skip if anything is breaking
+                details['attributes'][attr] = None
     return details
 
 


### PR DESCRIPTION
Allows to ignore codes, either in the CLI or in the configuration. Using the CLI overrides anything described in the configuration.

It also addresses the problem of possible exceptions being raised when trying to capture remote errors, adds tests to verify this.

Fixes issues: 
https://github.com/ceph/ceph-medic/issues/116
https://github.com/ceph/ceph-medic/issues/111