### PR TITLE
compat: swap the order of configparser import

### DIFF
--- a/ceph_medic/compat.py
+++ b/ceph_medic/compat.py
@@ -1,9 +1,9 @@
 # flake8: noqa
 
 try:
-    import configparser
-except ImportError:
     import ConfigParser as configparser
+except ImportError:
+    import configparser
 
 try:
     from ConfigParser import SafeConfigParser as BaseConfigParser


### PR DESCRIPTION
The compatibility layer can get messed up by the 'configparser' package
that is available in Python 2.7 which clashes with 3.6

By giving preference to importing from ConfigParser as it is in 2.7 we
prevent the problem of NoOptionError not showing up correctly.

Signed-off-by: Alfredo Deza <adeza@redhat.com>