### PR TITLE
Fix test bugs that were breaking rpm builds

### DIFF
--- a/ceph_medic/__init__.py
+++ b/ceph_medic/__init__.py
@@ -22,4 +22,4 @@ metadata = {'failed_nodes': {}, 'rgws': {}, 'mgrs': {}, 'mdss': {}, 'clients': {
 
 daemon_types = [i for i in metadata.keys() if i not in ('nodes', 'failed_nodes', 'cluster')]
 
-__version__ = '1.0.6'
+__version__ = '1.0.7'

--- a/ceph_medic/tests/test_main.py
+++ b/ceph_medic/tests/test_main.py
@@ -12,8 +12,8 @@ class TestMain(object):
         argv = ["ceph-medic", "--ssh-config", "/does/not/exist"]
         with pytest.raises(SystemExit):
             ceph_medic.main.Medic(argv)
-        out = capsys.readouterr()
-        assert 'the given ssh config path does not exist' in out.out
+        out, _ = capsys.readouterr()
+        assert 'the given ssh config path does not exist' in out
 
     def test_valid_ssh_config(self, capsys):
         ssh_config = '/etc/ssh/ssh_config'

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,14 @@
+ceph-medic (1.0.7) stable; urgency=medium
+
+  * New upstream release
+
+ -- Ceph Release Team <ceph-maintainers@ceph.com>  Tue, 24 Mar 2020 17:29:00 -0600
+
 ceph-medic (1.0.6) stable; urgency=medium
 
   * New upstream release
 
- -- Ceph Release Team <ceph-maintainers@ceph.com>  Tue, 11 Feb 2018 16:41:07 -0600
+ -- Ceph Release Team <ceph-maintainers@ceph.com>  Tue, 11 Feb 2020 16:41:07 -0600
 
 ceph-medic (1.0.4) stable; urgency=medium
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,3 +1,9 @@
+1.0.7
+-----
+24-Mar-2020
+
+* Fix test bugs that were breaking rpm builds
+
 1.0.6
 -----
 11-Feb-2020


### PR DESCRIPTION
Aside from the dependency issues, it turns out I made two mistakes when updating tests when I added the docker support.