### PR TITLE
add json output --format option

### DIFF
--- a/ceph_medic/__init__.py
+++ b/ceph_medic/__init__.py
@@ -18,8 +18,11 @@ config = namedtuple('config', ['verbosity', 'nodes', 'hosts_file', 'file', 'clus
 config.file = UnloadedConfig("No valid ceph-medic configuration file was loaded")
 config.nodes = {}
 
-metadata = {'failed_nodes': {}, 'rgws': {}, 'mgrs': {}, 'mdss': {}, 'clients': {}, 'osds': {}, 'mons': {}, 'nodes': {}, 'cluster': {}}
+metadata = {'failed_nodes': {}, 'rgws': {}, 'mgrs': {}, 'mdss': {}, 'clients': {}, 'osds': {}, 'mons': {}, 'nodes': {}, 'cluster': {}, 'results': {'info': {}, 'totals': {}}}
 
-daemon_types = [i for i in metadata.keys() if i not in ('nodes', 'failed_nodes', 'cluster')]
+daemon_types = [i for i in metadata.keys() if i not in ('nodes', 'failed_nodes', 'cluster', 'results')]
 
+for daemon_type in daemon_types:
+    metadata['results'][daemon_type] = {}
+    
 __version__ = '1.0.8'

--- a/ceph_medic/collector.py
+++ b/ceph_medic/collector.py
@@ -112,7 +112,7 @@ def get_path_metadata(conn, path, **kw):
     return {'dirs': dirs, 'files': files}
 
 
-def get_node_metadata(conn, hostname, cluster_nodes):
+def get_node_metadata(conn, hostname, cluster_nodes, loader=loader):
     # "import" the remote functions so that remote calls using the
     # functions can be executed
     conn.import_module(remote.functions)
@@ -145,7 +145,7 @@ def get_node_metadata(conn, hostname, cluster_nodes):
     return node_metadata
 
 
-def collect():
+def collect(term_writer=terminal.write, loader=loader):
     """
     The main collecting entrypoint. This function will call all the pieces
     needed to build the complete metadata set of a remote system so that checks
@@ -194,7 +194,7 @@ def collect():
 
             # send the full node metadata for global scope so that the checks
             # can consume this
-            metadata[node_type][hostname] = get_node_metadata(conn, hostname, cluster_nodes)
+            metadata[node_type][hostname] = get_node_metadata(conn, hostname, cluster_nodes, loader)
             if node_type == 'mons':  # if node type is monitor, admin privileges are most likely authorized
                 if not has_cluster_data:
                     cluster_data = collect_cluster(conn)
@@ -207,7 +207,7 @@ def collect():
         loader.write(terminal.red('Collection failed!') + ' ' *70)
         # TODO: this helps clear out the 'loader' line so that the error looks
         # clean, but this manual clearing should be done automatically
-        terminal.write.raw('')
+        term_writer.raw('')
         raise RuntimeError('All nodes failed to connect. Cannot run any checks')
     if failed_nodes:
         loader.write(terminal.yellow('Collection completed with some failed connections' + ' ' *70 + '\n'))

--- a/ceph_medic/terminal.py
+++ b/ceph_medic/terminal.py
@@ -108,12 +108,13 @@ _level_colors = {
 
 class _Write(object):
 
-    def __init__(self, _writer=None, prefix='', suffix='', clear_line=False, flush=False):
+    def __init__(self, _writer=None, prefix='', suffix='', clear_line=False, flush=False, enable=True):
         self._writer = _writer or sys.stdout
         self.suffix = suffix
         self.prefix = prefix
         self.flush = flush
         self.clear_line = clear_line
+        self.enabled = enable
 
     def bold(self, string):
         self.write(bold(string))
@@ -122,6 +123,8 @@ class _Write(object):
         self.write(string + '\n')
 
     def write(self, line):
+        if not self.enabled:
+            return
         padding = ''
         if self.clear_line:
             if len(line) > 80:

--- a/ceph_medic/tests/__init__.py
+++ b/ceph_medic/tests/__init__.py
@@ -1,5 +1,6 @@
 
 # helps reset altered metadata in tests
 base_metadata = {'rgws': {}, 'mgrs': {}, 'mdss':{}, 'clients': {},
-        'osds':{}, 'mons':{}, 'nodes': {}, 'cluster_name': 'ceph', 'failed_nodes': {}}
+                 'osds':{}, 'mons':{}, 'nodes': {}, 'cluster_name': 'ceph', 'failed_nodes': {},
+                 'results':  {'info': {}, 'totals': {}} }
 

--- a/ceph_medic/tests/test_collector.py
+++ b/ceph_medic/tests/test_collector.py
@@ -126,7 +126,7 @@ class TestCollect(object):
             "osds": [{"host": "osd0"}],
         }
         metadata["cluster_name"] = "ceph"
-        def mock_metadata(conn, hostname, cluster_nodes):
+        def mock_metadata(conn, hostname, cluster_nodes, loader):
             return dict(meta="data")
         monkeypatch.setattr(collector, "get_connection",
                             lambda host, container=None: Mock())

--- a/ceph_medic/tests/test_runner.py
+++ b/ceph_medic/tests/test_runner.py
@@ -1,6 +1,7 @@
 import ceph_medic
 from ceph_medic import runner
 from ceph_medic.tests import base_metadata
+from ceph_medic.tests.conftest import FakeWriter
 from textwrap import dedent
 from ceph_medic.util import configuration
 
@@ -36,54 +37,54 @@ class TestReport(object):
     def setup(self):
         runner.metadata = base_metadata
         runner.metadata['nodes'] = {}
-        self.results = runner.Runner()
+        self.results = runner.Runner(term_writer=FakeWriter())
 
-    def test_reports_unhandled_internal_errors(self, terminal):
+    def test_reports_unhandled_internal_errors(self):
         self.results.internal_errors = ['I am an error']
-        runner.report(self.results)
-        assert 'While running checks, ceph-medic had 1 unhandled errors' in terminal.calls[-1]
+        self.results.report()
+        assert 'While running checks, ceph-medic had 1 unhandled errors' in self.results.term_writer.calls[-1]
 
     def test_reports_no_errors(self, terminal):
-        runner.report(self.results)
-        assert terminal.calls[0] == '\n0 passed, on 0 hosts'
+        self.results.report()
+        assert self.results.term_writer.calls[0] == '\n0 passed, on 0 hosts'
 
     def test_reports_warning(self, terminal):
         self.results.warnings = 1
-        runner.report(self.results)
-        assert terminal.calls[0] == '\n0 passed, 1 warning, on 0 hosts'
+        self.results.report()
+        assert self.results.term_writer.calls[0] == '\n0 passed, 1 warning, on 0 hosts'
 
     def test_reports_warnings(self, terminal):
         self.results.warnings = 2
-        runner.report(self.results)
-        assert terminal.calls[0] == '\n0 passed, 2 warnings, on 0 hosts'
+        self.results.report()
+        assert self.results.term_writer.calls[0] == '\n0 passed, 2 warnings, on 0 hosts'
 
     def test_reports_error(self, terminal):
         self.results.errors = 1
-        runner.report(self.results)
-        assert terminal.calls[0] == '\n0 passed, 1 error, on 0 hosts'
+        self.results.report()
+        assert self.results.term_writer.calls[0] == '\n0 passed, 1 error, on 0 hosts'
 
     def test_reports_errors(self, terminal):
         self.results.errors = 2
-        runner.report(self.results)
-        assert terminal.calls[0] == '\n0 passed, 2 errors, on 0 hosts'
+        self.results.report()
+        assert self.results.term_writer.calls[0] == '\n0 passed, 2 errors, on 0 hosts'
 
     def test_reports_error_and_warning(self, terminal):
         self.results.errors = 1
         self.results.warnings = 1
-        runner.report(self.results)
-        assert terminal.calls[0] == '\n0 passed, 1 error, 1 warning, on 0 hosts'
+        self.results.report()
+        assert self.results.term_writer.calls[0] == '\n0 passed, 1 error, 1 warning, on 0 hosts'
 
     def test_reports_errors_and_warnings(self, terminal):
         self.results.errors = 2
         self.results.warnings = 2
-        runner.report(self.results)
-        assert terminal.calls[0] == '\n0 passed, 2 errors, 2 warnings, on 0 hosts'
+        self.results.report()
+        assert self.results.term_writer.calls[0] == '\n0 passed, 2 errors, 2 warnings, on 0 hosts'
 
     def test_reports_internal_errors(self, terminal):
         self.results.internal_errors = ['error 1', 'error 2']
         self.results.warnings = 2
-        runner.report(self.results)
-        assert terminal.calls[0] == '\n0 passed, 2 warnings, 2 internal errors, on 0 hosts'
+        self.results.report()
+        assert self.results.term_writer.calls[0] == '\n0 passed, 2 warnings, 2 internal errors, on 0 hosts'
 
 
 class TestReportBasicOutput(object):
@@ -97,40 +98,40 @@ class TestReportBasicOutput(object):
         ceph_medic.config.file = conf
         runner.metadata = base_metadata
         runner.metadata['cluster_name'] = 'ceph'
-        runner.Runner().run()
+        self.results = runner.Runner(term_writer=FakeWriter()).run()
 
     def teardown(self):
         runner.metadata = base_metadata
 
     def test_has_version(self, terminal):
-        assert 'Version: ' in terminal.get_output()
+        assert 'Version: ' in self.results.term_writer.get_output()
 
     def test_has_cluster_name(self, terminal):
-        assert 'Cluster Name: "ceph"' in terminal.get_output()
+        assert 'Cluster Name: "ceph"' in self.results.term_writer.get_output()
 
     def test_has_no_hosts(self, terminal):
-        assert 'Total hosts: [0]' in terminal.get_output()
+        assert 'Total hosts: [0]' in self.results.term_writer.get_output()
 
     def test_has_a_header(self, terminal):
-        assert '==  Starting remote check session  ==' in terminal.get_output()
+        assert '==  Starting remote check session  ==' in self.results.term_writer.get_output()
 
     def test_has_no_OSDs(self, terminal):
-        assert 'OSDs:    0' in terminal.get_output()
+        assert 'OSDs:    0' in self.results.term_writer.get_output()
 
     def test_has_no_MONs(self, terminal):
-        assert 'MONs:    0' in terminal.get_output()
+        assert 'MONs:    0' in self.results.term_writer.get_output()
 
     def test_has_no_Clients(self, terminal):
-        assert 'Clients:    0' in terminal.get_output()
+        assert 'Clients:    0' in self.results.term_writer.get_output()
 
     def test_has_no_MDSs(self, terminal):
-        assert 'MDSs:    0' in terminal.get_output()
+        assert 'MDSs:    0' in self.results.term_writer.get_output()
 
     def test_has_no_MGRs(self, terminal):
-        assert 'MGRs:       0' in terminal.get_output()
+        assert 'MGRs:       0' in self.results.term_writer.get_output()
 
     def test_has_no_RGWs(self, terminal):
-        assert 'RGWs:    0' in terminal.get_output()
+        assert 'RGWs:    0' in self.results.term_writer.get_output()
 
 
 class TestReportErrors(object):


### PR DESCRIPTION
Adds a new flag --format, which takes either 'json' or
'term' (default). if 'json' returns a json structure of the results
normally printed to the terminal

resolves #142, resolves #119